### PR TITLE
Added stopBeingDelegate in Adapter

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
@@ -143,6 +143,9 @@
     }
 }
 
+- (void)stopBeingDelegate {
+}
+
 #pragma mark Banner Methods
 
 - (void)getBannerWithSize:(GADAdSize)adSize {


### PR DESCRIPTION
This method is getting called when ` _adapterDidDismissInterstitial_:` triggered, without implement this, there will be an exception. Checked the example implementation, it does the following steps:
`- (void)stopBeingDelegate {
  _bannerAd.delegate = nil;
  _interstitialAd.delegate = nil;
  _nativeAdLoader.delegate = nil;
  _rewardBasedVideoAd.delegate = nil;
}` 
we did let our ad object to be `nil` in the closed callback, I think it is same here, so I just implemented a empty function here to avoid the exception.