### PR TITLE
Remove canShow check before every show

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
@@ -97,9 +97,7 @@
 }
 
 - (void)presentRewardBasedVideoAdWithRootViewController:(UIViewController *)viewController {
-  if ([_rewardedVideoAd canShow]) {
-    [_rewardedVideoAd showFromViewController:viewController];
-  }
+  [_rewardedVideoAd showFromViewController:viewController];
 }
 
 #pragma mark Interstitial Methods
@@ -137,10 +135,8 @@
 }
 
 - (void)presentInterstitialFromRootViewController:(UIViewController *)rootViewController {
-    if ([_interstitialAd canShow]) {
-      [_networkConnector adapterWillPresentInterstitial:self];
-      [_interstitialAd showFromViewController:rootViewController];
-    }
+    [_networkConnector adapterWillPresentInterstitial:self];
+    [_interstitialAd showFromViewController:rootViewController];
 }
 
 #pragma mark Banner Methods


### PR DESCRIPTION
The `canShow` method for Interstitial and Rewarded Ads needs to check the `viewController` is not nil, but before the adapter calls `presentRewardBasedVideoAdWithRootViewController`, the `viewController` is always `nil`, so just removed the `canShow` check, it will be checked later inside the `showFromViewController` in native sdk.