### PR TITLE
Deallocate rewardedAd object when it gets closed

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
@@ -84,12 +84,7 @@
 }
 
 - (void)requestRewardBasedVideoAd {
-  if (_rewardedVideoAd) {
-    if ([_rewardedVideoAd canShow]) {
-      id<GADMRewardBasedVideoAdNetworkConnector> strongRewardedConnector = _rewardBasedVideoAdConnector;
-      [strongRewardedConnector adapterDidReceiveRewardBasedVideoAd:self];
-    }
-  } else {
+  if (_rewardedVideoAd == nil) {
     _rewardedVideoAd = [[UADSRewardedVideoAd alloc] initWithPlacementId:_placementID];
     _rewardedVideoAd.delegate = self;
     [_rewardedVideoAd load];
@@ -191,8 +186,8 @@
 
 -(void)interstitialAdDidClose:(UADSInterstitialAd *)interstitialAd finishState:(UnityAdsFinishState)finishState {
   [_networkConnector adapterWillDismissInterstitial:self];
-  [_networkConnector adapterDidDismissInterstitial:self];
   _interstitialAd = nil;
+  [_networkConnector adapterDidDismissInterstitial:self];
 }
 
 #pragma mark - UADSRewardedVideoAdDelegate
@@ -222,6 +217,7 @@
 }
 -(void)rewardedVideoAdDidClose:(UADSRewardedVideoAd *)rewardedVideoAd finishState:(UnityAdsFinishState)finishState {
   [_rewardBasedVideoAdConnector adapterDidCloseRewardBasedVideoAd:self];
+  _rewardedVideoAd = nil;
 }
 -(void)rewardedVideoAdDidInvalidate:(UADSRewardedVideoAd *)rewardedVideoAd {
 


### PR DESCRIPTION
1. Deallocation rewardedAd object when `rewardedVideoAdDidClose` is called.
2. Change the position of deallocation `_interstitialAd` and `adapterDidDismissInterstitial`.
3. Delete the never get called code in `requestRewardBasedVideoAd`, since the `adapterDidReceiveRewardBasedVideoAd` is always called from `rewardedVideoAdDidLoad`, int `requestRewardBasedVideoAd` the `canShow` will always be `false` if the ads is not loaded.